### PR TITLE
streamlit and pandas helpers

### DIFF
--- a/.github/workflows/test_loader_bigquery.yml
+++ b/.github/workflows/test_loader_bigquery.yml
@@ -8,10 +8,10 @@ on:
   workflow_dispatch:
 
 env:
-  PROJECT_ID: chat-analytics-rasa-ci
-  CLIENT_EMAIL: chat-analytics-loader@chat-analytics-rasa-ci.iam.gserviceaccount.com
-  PRIVATE_KEY: ${{ secrets.BQ_CRED_PRIVATE_KEY }}
-  TOKEN_URI: https://oauth2.googleapis.com/token
+  GCP__PROJECT_ID: chat-analytics-rasa-ci
+  GCP__CLIENT_EMAIL: chat-analytics-loader@chat-analytics-rasa-ci.iam.gserviceaccount.com
+  GCP__PRIVATE_KEY: ${{ secrets.BQ_CRED_PRIVATE_KEY }}
+  GCP__TOKEN_URI: https://oauth2.googleapis.com/token
   DEFAULT_DATASET: workflowtest
 
 jobs:

--- a/.github/workflows/test_loader_redshift.yml
+++ b/.github/workflows/test_loader_redshift.yml
@@ -8,10 +8,10 @@ on:
   workflow_dispatch:
 
 env:
-  HOST: 3.73.90.3
-  USER: loader
-  PASSWORD: ${{ secrets.PG_PASSWORD }}
-  DBNAME: chat_analytics_rasa_ci
+  PG__HOST: 3.73.90.3
+  PG__USER: loader
+  PG__PASSWORD: ${{ secrets.PG_PASSWORD }}
+  PG__DBNAME: chat_analytics_rasa_ci
   DEFAULT_DATASET: workflowtest
 
 jobs:

--- a/dlt/common/configuration/__init__.py
+++ b/dlt/common/configuration/__init__.py
@@ -1,11 +1,11 @@
-from .run_configuration import RunConfiguration, BaseConfiguration  # noqa: F401
+from .run_configuration import RunConfiguration, BaseConfiguration, CredentialsConfiguration  # noqa: F401
 from .normalize_volume_configuration import NormalizeVolumeConfiguration, ProductionNormalizeVolumeConfiguration  # noqa: F401
 from .load_volume_configuration import LoadVolumeConfiguration, ProductionLoadVolumeConfiguration  # noqa: F401
 from .schema_volume_configuration import SchemaVolumeConfiguration, ProductionSchemaVolumeConfiguration  # noqa: F401
 from .pool_runner_configuration import PoolRunnerConfiguration, TPoolType  # noqa: F401
 from .gcp_client_credentials import GcpClientCredentials  # noqa: F401
 from .postgres_credentials import PostgresCredentials  # noqa: F401
-from .utils import make_configuration, TSecretValue  # noqa: F401
+from .utils import make_configuration  # noqa: F401
 
 from .exceptions import (  # noqa: F401
     ConfigEntryMissingException, ConfigEnvValueCannotBeCoercedException, ConfigIntegrityException, ConfigFileNotFoundException)

--- a/dlt/common/configuration/exceptions.py
+++ b/dlt/common/configuration/exceptions.py
@@ -11,9 +11,14 @@ class ConfigurationException(DltException):
 class ConfigEntryMissingException(ConfigurationException):
     """thrown when not all required config elements are present"""
 
-    def __init__(self, missing_set: Iterable[str]) -> None:
+    def __init__(self, missing_set: Iterable[str], namespace: str = None) -> None:
         self.missing_set = missing_set
-        super().__init__('Missing config keys: ' + str(missing_set))
+        self.namespace = namespace
+
+        msg = 'Missing config keys: ' + str(missing_set)
+        if namespace:
+            msg += ". Note that required namespace for that keys is " + namespace + " and namespace separator is two underscores"
+        super().__init__(msg)
 
 
 class ConfigEnvValueCannotBeCoercedException(ConfigurationException):

--- a/dlt/common/configuration/gcp_client_credentials.py
+++ b/dlt/common/configuration/gcp_client_credentials.py
@@ -1,11 +1,13 @@
-from dlt.common.typing import StrAny, StrStr
-from dlt.common.configuration import BaseConfiguration
-from dlt.common.configuration.utils import TSecretValue
+from dlt.common.typing import StrAny, TSecretValue
+from dlt.common.configuration import CredentialsConfiguration
 
 
-class GcpClientCredentials(BaseConfiguration):
+class GcpClientCredentials(CredentialsConfiguration):
+
+    __namespace__: str = "GCP"
+
     PROJECT_ID: str = None
-    BQ_CRED_TYPE: str = "service_account"
+    CRED_TYPE: str = "service_account"
     PRIVATE_KEY: TSecretValue = None
     TOKEN_URI: str = "https://oauth2.googleapis.com/token"
     CLIENT_EMAIL: str = None
@@ -22,7 +24,7 @@ class GcpClientCredentials(BaseConfiguration):
     @classmethod
     def as_credentials(cls) -> StrAny:
         return {
-                "type": cls.BQ_CRED_TYPE,
+                "type": cls.CRED_TYPE,
                 "project_id": cls.PROJECT_ID,
                 "private_key": cls.PRIVATE_KEY,
                 "token_uri": cls.TOKEN_URI,

--- a/dlt/common/configuration/postgres_credentials.py
+++ b/dlt/common/configuration/postgres_credentials.py
@@ -1,9 +1,11 @@
-from dlt.common.configuration import BaseConfiguration
-from dlt.common.configuration.utils import TSecretValue
-from dlt.common.typing import StrAny
+from dlt.common.typing import StrAny, TSecretValue
+from dlt.common.configuration import CredentialsConfiguration
 
 
-class PostgresCredentials(BaseConfiguration):
+class PostgresCredentials(CredentialsConfiguration):
+
+    __namespace__: str = "PG"
+
     DBNAME: str = None
     PASSWORD: TSecretValue = None
     USER: str = None

--- a/dlt/common/configuration/providers/environ.py
+++ b/dlt/common/configuration/providers/environ.py
@@ -1,0 +1,40 @@
+from os import environ
+from os.path import isdir
+from typing import Any, Optional, Type
+
+from dlt.common.typing import TSecretValue
+
+SECRET_STORAGE_PATH: str = "/run/secrets/%s"
+
+
+def get_key_name(key: str, namespace: str = None) -> str:
+    if namespace:
+        return namespace + "__" + key
+    else:
+        return key
+
+
+def get_key(key: str, hint: Type[Any], namespace: str = None) -> Optional[str]:
+    # apply namespace to the key
+    key = get_key_name(key, namespace)
+    if hint is TSecretValue:
+        # try secret storage
+        try:
+            # must conform to RFC1123
+            secret_name = key.lower().replace("_", "-")
+            secret_path = SECRET_STORAGE_PATH % secret_name
+            # kubernetes stores secrets as files in a dir, docker compose plainly
+            if isdir(secret_path):
+                secret_path += "/" + secret_name
+            with open(secret_path, "r", encoding="utf-8") as f:
+                secret = f.read()
+            # add secret to environ so forks have access
+            # TODO: removing new lines is not always good. for password OK for PEMs not
+            # TODO: in regular secrets that is dealt with in particular configuration logic
+            environ[key] = secret.strip()
+            # do not strip returned secret
+            return secret
+        # includes FileNotFound
+        except OSError:
+            pass
+    return environ.get(key, None)

--- a/dlt/common/configuration/run_configuration.py
+++ b/dlt/common/configuration/run_configuration.py
@@ -2,7 +2,7 @@ import randomname
 from os.path import isfile
 from typing import Any, Optional, Tuple, IO
 
-from dlt.common.typing import StrAny
+from dlt.common.typing import StrAny, DictStrAny
 from dlt.common.utils import encoding_for_mode
 from dlt.common.configuration.exceptions import ConfigFileNotFoundException
 
@@ -14,9 +14,10 @@ class BaseConfiguration:
 
     # will be set to true if not all config entries could be resolved
     __is_partial__: bool = True
+    __namespace__: str = None
 
     @classmethod
-    def as_dict(config, lowercase: bool = True) -> StrAny:
+    def as_dict(config, lowercase: bool = True) -> DictStrAny:
         may_lower = lambda k: k.lower() if lowercase else k
         return {may_lower(k):getattr(config, k) for k in dir(config) if not callable(getattr(config, k)) and not k.startswith("__")}
 
@@ -30,6 +31,10 @@ class BaseConfiguration:
             # overwrite only declared values
             if not apply_non_spec and hasattr(config, k):
                 setattr(config, k, v)
+
+
+class CredentialsConfiguration(BaseConfiguration):
+    pass
 
 
 class RunConfiguration(BaseConfiguration):

--- a/dlt/common/dataset_writers.py
+++ b/dlt/common/dataset_writers.py
@@ -5,7 +5,7 @@ from typing import Any, Iterable, Literal, Sequence, IO
 from dlt.common import json
 from dlt.common.typing import StrAny
 
-TLoaderFileFormat = Literal["jsonl", "insert_values"]
+TWriterType = Literal["jsonl", "insert_values"]
 
 
 def write_jsonl(f: IO[Any], rows: Sequence[Any]) -> None:

--- a/dlt/common/dataset_writers.py
+++ b/dlt/common/dataset_writers.py
@@ -5,7 +5,7 @@ from typing import Any, Iterable, Literal, Sequence, IO
 from dlt.common import json
 from dlt.common.typing import StrAny
 
-TWriterType = Literal["jsonl", "insert_values"]
+TLoaderFileFormat = Literal["jsonl", "insert_values"]
 
 
 def write_jsonl(f: IO[Any], rows: Sequence[Any]) -> None:

--- a/dlt/common/utils.py
+++ b/dlt/common/utils.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 import hashlib
 from os import environ
 import secrets
-from typing import Any, Iterator, Optional, Sequence, TypeVar, Mapping, List, TypedDict, Union
+from typing import Any, Dict, Iterator, Optional, Sequence, TypeVar, Mapping, List, TypedDict, Union
 
 from dlt.common.typing import StrAny, DictStrAny, StrStr, TFun
 
@@ -124,6 +124,13 @@ def update_dict_with_prune(dest: DictStrAny, update: StrAny) -> None:
 def is_interactive() -> bool:
     import __main__ as main
     return not hasattr(main, '__file__')
+
+
+def dict_remove_nones_in_place(d: Dict[Any, Any]) -> Dict[Any, Any]:
+    for k in list(d.keys()):
+        if d[k] is None:
+            del d[k]
+    return d
 
 
 @contextmanager

--- a/dlt/common/wei.py
+++ b/dlt/common/wei.py
@@ -1,0 +1,78 @@
+import functools
+import hexbytes
+from typing import Any
+
+from dlt.common import Decimal
+from dlt.common.arithmetics import Context, default_context, decimal
+from dlt.common.typing import StrAny
+
+# default scale of platform contracts
+WEI_SCALE = 18
+# log(2^256) + 1
+EVM_DECIMAL_PRECISION = 78
+# value of one at wei scale
+WEI_SCALE_POW = 10**18
+
+
+# class WeiDecimal(Decimal):
+#     ctx = default_context(decimal.getcontext().copy(), EVM_DECIMAL_PRECISION)
+#     def __new__(cls, *args: Any, **kwargs: Any) -> "Wei":
+#         c = default_context(decimal.getcontext().copy(), EVM_DECIMAL_PRECISION)
+#         d = super(WeiDecimal, cls).__new__(cls, *args, **kwargs, context=c)
+#         d.c = c
+#         # d.c = default_context(decimal.getcontext().copy(), EVM_DECIMAL_PRECISION)
+#         return d
+
+#     def __getattribute__(self, __name: str) -> Any:
+#         rv = super().__getattribute__(__name)
+#         if callable(rv) and not __name.startswith("_"):
+#             if "context" in rv.func_code.co_varnames:
+#                 return functools.partialmethod(rv, context=self.c)
+#         return rv
+
+#     def __repr__(self) -> str:
+#         return super().__repr__().replace("Decimal", "Wei")
+
+
+class Wei(Decimal):
+
+    ctx = default_context(decimal.getcontext().copy(), EVM_DECIMAL_PRECISION)
+
+    # def __slots__hints__(self) -> None:
+    #     self._scale: int = 0
+
+    # def __new__(cls, value: int, scale: int = 0) -> "Wei":
+    #     self = super(Wei, cls).__new__(cls, value)
+    #     self._scale = scale
+    #     return self
+
+    # def __init__(self, value: int, scale: int = 0) -> None:
+    #     self._c = default_context(decimal.getcontext().copy(), EVM_DECIMAL_PRECISION)
+    #     self.value = value
+    #     self.scale = scale
+
+
+    # def to_decimal():
+    #     pass
+
+    # def __get__(self, obj, type=None) -> object:
+    #     print("GET!")
+    #     if self.normalize(self.ctx) > 100:
+    #         return "STR"
+    #     else:
+    #         return self
+
+    def __new__(cls, value: int, scale: int = 0) -> "Wei":
+        d: "Wei" = None
+        if scale == 0:
+            d = super(Wei, cls).__new__(cls, value)
+        else:
+            d = super(Wei, cls).__new__(cls, Decimal(value, context=cls.ctx) / 10**scale)
+
+        return d
+
+    # def from_uint256(value: int, scale: int = 0):
+    #     pass
+
+    # # def __repr__(self) -> str:
+    # #     return f"{self.scale},{self.value}"

--- a/dlt/dbt_runner/configuration.py
+++ b/dlt/dbt_runner/configuration.py
@@ -1,7 +1,8 @@
 from typing import List, Optional, Type
 
-from dlt.common.typing import StrAny
-from dlt.common.configuration.utils import TSecretValue, make_configuration, _get_key_value
+from dlt.common.typing import StrAny, TSecretValue
+from dlt.common.configuration import make_configuration
+from dlt.common.configuration.providers import environ
 from dlt.common.configuration import PoolRunnerConfiguration, TPoolType, PostgresCredentials, GcpClientCredentials
 
 from . import __version__
@@ -44,9 +45,9 @@ def gen_configuration_variant(initial_values: StrAny = None) -> Type[DBTRunnerCo
     DBTRunnerConfigurationImpl: Type[DBTRunnerConfiguration]
     DBTRunnerProductionConfigurationImpl: Type[DBTRunnerProductionConfiguration]
 
-    source_schema_prefix = _get_key_value("DEFAULT_DATASET", type(str))
+    source_schema_prefix = environ.get_key("DEFAULT_DATASET", type(str))
 
-    if _get_key_value("PROJECT_ID", type(str)):
+    if environ.get_key("PROJECT_ID", type(str), namespace=GcpClientCredentials.__namespace__):
         class DBTRunnerConfigurationPostgres(PostgresCredentials, DBTRunnerConfiguration):
             SOURCE_SCHEMA_PREFIX: str = source_schema_prefix
         DBTRunnerConfigurationImpl = DBTRunnerConfigurationPostgres

--- a/dlt/helpers/pandas.py
+++ b/dlt/helpers/pandas.py
@@ -1,0 +1,54 @@
+from typing import Any
+
+from dlt.pipeline.exceptions import MissingDependencyException
+from dlt.load.client_base import SqlClientBase
+
+try:
+    import pandas as pd
+    from pandas.io.sql import _wrap_result
+except ImportError:
+    raise MissingDependencyException("DLT Pandas Helpers", ["pandas"])
+
+
+
+def query_results_to_df(
+    client: SqlClientBase[Any], query: str, index_col: Any = None, coerce_float: bool = True, parse_dates: Any = None, dtype: Any = None
+) -> pd.DataFrame:
+    """
+    A helper function that executes a query in the destination and returns the result as Pandas `DataFrame`
+
+    This method reuses `read_sql` method of `Pandas` with the sql client obtained from `Pipeline.sql_client` method.
+
+    Parameters
+    ----------
+    client (SqlClientBase[Any]): Sql Client instance
+    query (str): Query to be executed
+    index_col str or list of str, optional, default: None
+        Column(s) to set as index(MultiIndex).
+    coerce_float (bool, optional): default: True
+        Attempts to convert values of non-string, non-numeric objects (like
+        decimal.Decimal) to floating point. Useful for SQL result sets.
+    parse_dates : list or dict, default: None
+        - List of column names to parse as dates.
+        - Dict of ``{column_name: format string}`` where format string is
+            strftime compatible in case of parsing string times, or is one of
+            (D, s, ns, ms, us) in case of parsing integer timestamps.
+        - Dict of ``{column_name: arg dict}``, where the arg dict corresponds
+            to the keyword arguments of :func:`pandas.to_datetime`
+            Especially useful with databases without native Datetime support,
+            such as SQLite.
+    dtype : Type name or dict of columns
+        Data type for data or columns. E.g. np.float64 or
+        {‘a’: np.float64, ‘b’: np.int32, ‘c’: ‘Int64’}.
+
+    Returns
+    -------
+    DataFrame with the query results
+    """
+    with client.execute_query(query) as curr:
+        # get column names
+        columns = [c[0] for c in curr.description]
+        # use existing panda function that converts results to data frame
+        # TODO: we may use `_wrap_iterator` to prevent loading the full result to memory first
+        pf: pd.DataFrame = _wrap_result(curr.fetchall(), columns, index_col, coerce_float, parse_dates, dtype)
+    return pf

--- a/dlt/helpers/streamlit.py
+++ b/dlt/helpers/streamlit.py
@@ -1,0 +1,170 @@
+
+import os
+import tomlkit
+from tomlkit.container import Container as TomlContainer
+from typing import cast
+from copy import deepcopy
+
+from dlt.pipeline import Pipeline
+from dlt.pipeline.typing import credentials_from_dict
+from dlt.pipeline.exceptions import MissingDependencyException, PipelineException
+from dlt.helpers.pandas import query_results_to_df, pd
+from dlt.common.configuration.run_configuration import BaseConfiguration, CredentialsConfiguration
+from dlt.common.utils import dict_remove_nones_in_place
+
+try:
+    import streamlit as st
+    from streamlit import SECRETS_FILE_LOC, secrets
+except ImportError:
+    raise MissingDependencyException("DLT Streamlit Helpers", ["streamlit"], "DLT Helpers for Streamlit should be run within a streamlit app.")
+
+
+def restore_pipeline() -> Pipeline:
+    """Restores Pipeline instance and associated credentials from Streamlit secrets
+
+        Current implementation requires that pipeline working dir is available at the location saved in secrets.
+
+    Raises:
+        PipelineBackupNotFound: Raised when pipeline backup is not available
+        CannotRestorePipelineException: Raised when pipeline working dir is not found or invalid
+
+    Returns:
+        Pipeline: Instance of pipeline with attached credentials
+    """
+    if "dlt" not in secrets:
+        raise PipelineException("You must backup pipeline to Streamlit first")
+    dlt_cfg = secrets["dlt"]
+    credentials = deepcopy(dict(dlt_cfg["destination"]))
+    if "DEFAULT_SCHEMA_NAME" in credentials:
+        del credentials["DEFAULT_SCHEMA_NAME"]
+    credentials.update(dlt_cfg["credentials"])
+    pipeline = Pipeline(dlt_cfg["pipeline_name"])
+    pipeline.restore_pipeline(credentials_from_dict(credentials), dlt_cfg["working_dir"])
+    return pipeline
+
+
+def backup_pipeline(pipeline: Pipeline) -> None:
+    """Backups pipeline state to the `secrets.toml` of the Streamlit app.
+
+    Pipeline credentials and working directory will be added to the Streamlit `secrets` file. This allows to access query the data loaded to the destination and
+    access definitions of the inferred schemas. See `restore_pipeline` and `write_data_explorer_page` functions in the same module.
+
+    Args:
+        pipeline (Pipeline): Pipeline instance, typically restored with `restore_pipeline`
+    """
+    # save pipeline state to project .config
+    # config_file_name = file_util.get_project_streamlit_file_path("config.toml")
+
+    # save credentials to secrets
+    if os.path.isfile(SECRETS_FILE_LOC):
+        with open(SECRETS_FILE_LOC, "r", encoding="utf-8") as f:
+            # use whitespace preserving parser
+            secrets = tomlkit.load(f)
+    else:
+        secrets = tomlkit.document()
+
+    # save general settings
+    secrets["dlt"] = {
+        "working_dir": pipeline.working_dir,
+        "pipeline_name": pipeline.pipeline_name
+    }
+
+    # get client config
+    # TODO: pipeline api v2 should provide a direct method to get configurations
+    CONFIG: BaseConfiguration = pipeline._loader_instance.load_client_cls.CONFIG  # type: ignore
+    CREDENTIALS: CredentialsConfiguration = pipeline._loader_instance.load_client_cls.CREDENTIALS  # type: ignore
+
+    # save client config
+    # print(dict_remove_nones_in_place(CONFIG.as_dict(lowercase=False)))
+    dlt_c = cast(TomlContainer, secrets["dlt"])
+    dlt_c["destination"] = dict_remove_nones_in_place(CONFIG.as_dict(lowercase=False))
+    dlt_c["credentials"] = dict_remove_nones_in_place(CREDENTIALS.as_dict(lowercase=False))
+
+    with open(SECRETS_FILE_LOC, "w", encoding="utf-8") as f:
+        # use whitespace preserving parser
+        tomlkit.dump(secrets, f)
+
+
+def write_data_explorer_page(pipeline: Pipeline, schema_name: str = None, show_dlt_tables: bool = False, example_query: str = "", show_charts: bool = True) -> None:
+    """Writes Streamlit app page with a schema and live data preview.
+
+    Args:
+        pipeline (Pipeline): Pipeline instance to use.
+        schema_name (str, optional): Name of the schema to display. If None, default schema is used.
+        show_dlt_tables (bool, optional): Should show DLT internal tables. Defaults to False.
+        example_query (str, optional): Example query to be displayed in the SQL Query box.
+        show_charts (bool, optional): Should automatically show charts for the queries from SQL Query box. Defaults to True.
+
+    Raises:
+        MissingDependencyException: Raised when a particular python dependency is not installed
+    """
+    @st.experimental_memo(ttl=600)
+    def run_query(query: str) -> pd.DataFrame:
+        # dlt pipeline exposes configured sql client that (among others) let's you make queries against the warehouse
+        with pipeline.sql_client(schema_name) as client:
+            df = query_results_to_df(client, query)
+            return df
+
+    if schema_name:
+        schema = pipeline.get_schema(schema_name)
+    else:
+        schema = pipeline.get_default_schema()
+    st.title(f"Available tables in {schema.name} schema")
+    # st.text(schema.to_pretty_yaml())
+
+    for table in schema.all_tables(with_dlt_tables=show_dlt_tables):
+        table_name = table["name"]
+        st.header(table_name)
+        if "description" in table:
+            st.text(table["description"])
+        if "parent" in table:
+            st.text("Parent table: " + table["parent"])
+
+        # table schema contains various hints (like clustering or partition options) that we do not want to show in basic view
+        essentials_f = lambda c: {k:v for k, v in c.items() if k in ["name", "data_type", "nullable"]}
+
+        st.table(map(essentials_f, table["columns"].values()))
+        # add a button that when pressed will show the full content of a table
+        if st.button("SHOW DATA", key=table_name):
+            st.text(f"Full {table_name} table content")
+            st.dataframe(run_query(f"SELECT * FROM {table_name}"))
+
+    st.title("Run your query")
+    sql_query = st.text_area("Enter your SQL query", value=example_query)
+    if st.button("Run Query"):
+        if sql_query:
+            st.text("Results of a query")
+            try:
+                # run the query from the text area
+                df = run_query(sql_query)
+                # and display the results
+                st.dataframe(df)
+
+                try:
+                    # now if the dataset has supported shape try to display the bar or altair chart
+                    if df.dtypes.shape[0] == 1 and show_charts:
+                        # try barchart
+                        st.bar_chart(df)
+                    if df.dtypes.shape[0] == 2 and show_charts:
+
+                        # try to import altair charts
+                        try:
+                            import altair as alt
+                        except ImportError:
+                            raise MissingDependencyException(
+                                "DLT Streamlit Helpers",
+                                ["altair"],
+                                "DLT Helpers for Streamlit should be run within a streamlit app."
+                            )
+
+                        # try altair
+                        bar_chart = alt.Chart(df).mark_bar().encode(
+                            x=f'{df.columns[1]}:Q',
+                            y=alt.Y(f'{df.columns[0]}:N', sort='-x')
+                        )
+                        st.altair_chart(bar_chart, use_container_width=True)
+                except Exception as ex:
+                    st.error(f"Chart failed due to: {ex}")
+            except Exception as ex:
+                st.text("Exception when running query")
+                st.exception(ex)

--- a/dlt/load/bigquery/client.py
+++ b/dlt/load/bigquery/client.py
@@ -114,7 +114,7 @@ class BigQuerySqlClient(SqlClientBase[bigquery.Client]):
             return None
 
     @contextmanager
-    def execute_query(self, query: AnyStr,  *args: Any, **kwargs: Any) -> Iterator[DBCursor]:  # type: ignore
+    def execute_query(self, query: AnyStr,  *args: Any, **kwargs: Any) -> Iterator[DBCursor]:
         conn: DbApiConnection = None
         def_kwargs = {
             "job_config": self.default_query
@@ -343,9 +343,9 @@ class BigQueryClient(SqlJobClientBase):
         }
 
     @classmethod
-    def configure(cls, initial_values: StrAny = None) -> Type[BigQueryClientConfiguration]:
+    def configure(cls, initial_values: StrAny = None) -> Tuple[Type[BigQueryClientConfiguration], Type[GcpClientCredentials]]:
         cls.CONFIG, cls.CREDENTIALS = configuration(initial_values=initial_values)
-        return cls.CONFIG
+        return cls.CONFIG, cls.CREDENTIALS
 
 
 CLIENT = BigQueryClient

--- a/dlt/load/bigquery/configuration.py
+++ b/dlt/load/bigquery/configuration.py
@@ -25,7 +25,7 @@ def configuration(initial_values: StrAny = None) -> Tuple[Type[BigQueryClientCon
                 # if so then return partial so we can access timeouts
                 C_PARTIAL = make_configuration(GcpClientCredentials, GcpClientCredentials, initial_values=initial_values, accept_partial = True)
                 # set the project id - it needs to be known by the client
-                C_PARTIAL.PROJECT_ID = project_id
+                C_PARTIAL.PROJECT_ID = C_PARTIAL.PROJECT_ID or project_id
                 return C_PARTIAL
             except DefaultCredentialsError:
                 raise cfex

--- a/dlt/load/client_base.py
+++ b/dlt/load/client_base.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from types import TracebackType
-from typing import Any, Generic, Iterator, List, Optional, Sequence, Type, AnyStr
+from typing import Any, ContextManager, Generic, Iterator, List, Optional, Sequence, Tuple, Type, AnyStr
 from pathlib import Path
 
 from dlt.common import pendulum, logger
-from dlt.common.configuration import BaseConfiguration
+from dlt.common.configuration import BaseConfiguration, CredentialsConfiguration
 from dlt.common.schema import TColumnSchema, Schema, TTableSchemaColumns
 from dlt.common.schema.typing import TTableSchema
 from dlt.common.typing import StrAny
@@ -101,7 +101,7 @@ class JobClientBase(ABC):
 
     @classmethod
     @abstractmethod
-    def configure(cls, initial_values: StrAny = None) -> Type[BaseConfiguration]:
+    def configure(cls, initial_values: StrAny = None) -> Tuple[Type[BaseConfiguration], Type[CredentialsConfiguration]]:
         pass
 
 
@@ -147,7 +147,7 @@ class SqlClientBase(ABC, Generic[TNativeConn]):
         pass
 
     @abstractmethod
-    def execute_query(self, query: AnyStr, *args: Any, **kwargs: Any) -> Iterator[DBCursor]:
+    def execute_query(self, query: AnyStr, *args: Any, **kwargs: Any) -> ContextManager[DBCursor]:
         pass
 
     @abstractmethod

--- a/dlt/load/dummy/client.py
+++ b/dlt/load/dummy/client.py
@@ -1,12 +1,12 @@
 import random
 from types import TracebackType
-from typing import Dict, Literal, Type
+from typing import Dict, Tuple, Type
 from dlt.common.dataset_writers import TLoaderFileFormat
 
 from dlt.common import pendulum
 from dlt.common.schema import Schema
 from dlt.common.schema.typing import TTableSchema
-from dlt.common.storages.load_storage import LoadStorage
+from dlt.common.configuration import CredentialsConfiguration
 from dlt.common.typing import StrAny
 
 from dlt.load.client_base import JobClientBase, LoadJob, TLoaderCapabilities
@@ -134,9 +134,9 @@ class DummyClient(JobClientBase):
         }
 
     @classmethod
-    def configure(cls, initial_values: StrAny = None) -> Type[DummyClientConfiguration]:
+    def configure(cls, initial_values: StrAny = None) -> Tuple[Type[DummyClientConfiguration], Type[CredentialsConfiguration]]:
         cls.CONFIG = configuration(initial_values=initial_values)
-        return cls.CONFIG
+        return cls.CONFIG, None
 
 
 CLIENT = DummyClient

--- a/dlt/load/redshift/client.py
+++ b/dlt/load/redshift/client.py
@@ -113,7 +113,7 @@ class RedshiftSqlClient(SqlClientBase["psycopg2.connection"]):
                 raise outer
 
     @contextmanager
-    def execute_query(self, query: AnyStr, *args: Any, **kwargs: Any) -> Iterator[DBCursor]:  # type: ignore
+    def execute_query(self, query: AnyStr, *args: Any, **kwargs: Any) -> Iterator[DBCursor]:
         curr: DBCursor = None
         with self._conn.cursor() as curr:
             try:
@@ -313,9 +313,9 @@ class RedshiftClient(SqlJobClientBase):
         }
 
     @classmethod
-    def configure(cls, initial_values: StrAny = None) -> Type[RedshiftClientConfiguration]:
+    def configure(cls, initial_values: StrAny = None) -> Tuple[Type[RedshiftClientConfiguration], Type[PostgresCredentials]]:
         cls.CONFIG, cls.CREDENTIALS = configuration(initial_values=initial_values)
-        return cls.CONFIG
+        return cls.CONFIG, cls.CREDENTIALS
 
 
 CLIENT = RedshiftClient

--- a/dlt/pipeline/exceptions.py
+++ b/dlt/pipeline/exceptions.py
@@ -43,6 +43,12 @@ class CannotRestorePipelineException(PipelineException):
         super().__init__(reason)
 
 
+class PipelineBackupNotFound(PipelineException):
+    def __init__(self, method: str) -> None:
+        self.method = method
+        super().__init__(f"Backup not found for method {method}")
+
+
 class SqlClientNotAvailable(PipelineException):
     def __init__(self, client_type: str) -> None:
         super().__init__(f"SQL Client not available in {client_type}")

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -229,9 +229,9 @@ class Pipeline:
             client.initialize_storage()
             client.update_storage_schema()
 
-    def sql_client(self) -> SqlClientBase[Any]:
+    def sql_client(self, schema_name: str = None) -> SqlClientBase[Any]:
         self._verify_loader_instance()
-        schema = self._normalize_instance.schema_storage.load_schema(self.default_schema_name)
+        schema = self._normalize_instance.schema_storage.load_schema(schema_name or self.default_schema_name)
         with self._loader_instance.load_client_cls(schema) as c:
             if isinstance(c, SqlJobClientBase):
                 return c.sql_client

--- a/dlt/pipeline/typing.py
+++ b/dlt/pipeline/typing.py
@@ -59,8 +59,8 @@ class GCPPipelineCredentials(PipelineCredentials):
         return GCPPipelineCredentials.from_services_dict(services, dataset_prefix)
 
     @classmethod
-    def default_credentials(cls, dataset_prefix: str) -> "GCPPipelineCredentials":
-        return cls("bigquery", None, dataset_prefix, None)
+    def default_credentials(cls, dataset_prefix: str, project_id: str = None) -> "GCPPipelineCredentials":
+        return cls("bigquery", project_id, dataset_prefix, None)
 
 
 @dataclass

--- a/dlt/pipeline/typing.py
+++ b/dlt/pipeline/typing.py
@@ -3,8 +3,7 @@ from dataclasses import dataclass
 from typing import Literal
 from dlt.common import json
 
-from dlt.common.typing import StrAny
-from dlt.common.configuration.utils import TSecretValue
+from dlt.common.typing import StrAny, TSecretValue
 
 TLoaderType = Literal["bigquery", "redshift"]
 TPipelineStage = Literal["extract", "normalize", "load"]
@@ -35,6 +34,8 @@ class GCPPipelineCredentials(PipelineCredentials):
     DEFAULT_DATASET: str
     CLIENT_EMAIL: str
     PRIVATE_KEY: TSecretValue = None
+    CRED_TYPE: str = "service_account"
+    TOKEN_URI: str = "https://oauth2.googleapis.com/token"
     HTTP_TIMEOUT: float = 15.0
     RETRY_DEADLINE: float = 600
 
@@ -80,3 +81,13 @@ class PostgresPipelineCredentials(PipelineCredentials):
     @default_dataset.setter
     def default_dataset(self, new_value: str) -> None:
         self.DEFAULT_DATASET = new_value
+
+
+def credentials_from_dict(credentials: StrAny) -> PipelineCredentials:
+    client_type = credentials.get("CLIENT_TYPE")
+    if client_type == "bigquery":
+        return GCPPipelineCredentials(**credentials)
+    elif client_type == "redshift":
+        return PostgresPipelineCredentials(**credentials)
+    else:
+        raise ValueError(f"CLIENT_TYPE: {client_type}")

--- a/examples/demo_example.py
+++ b/examples/demo_example.py
@@ -79,8 +79,8 @@ if __name__ == "__main__":
     # working BQ creds
     # credentials = Pipeline.load_gcp_credentials("_secrets/project1234_service.json", "gamma_guild")
 
-    # working redshift creds, you can pass password as last parameter or via PASSWORD env variable ie.
-    # LOG_LEVEL=INFO PASSWORD=.... python examples/discord_iterator.py
+    # working redshift creds, you can pass password as last parameter or via PG__PASSWORD env variable ie.
+    # LOG_LEVEL=INFO PG__PASSWORD=.... python examples/discord_iterator.py
     credentials = GCPPipelineCredentials.from_services_file(gcp_credential_json_file_path, schema_prefix)
 
     pipeline = Pipeline(schema_source_suffix)

--- a/examples/discord_iterator.py
+++ b/examples/discord_iterator.py
@@ -18,8 +18,8 @@ from dlt.pipeline import Pipeline, PostgresPipelineCredentials
 # credentials = Pipeline.load_gcp_credentials("_secrets/project1234_service.json", "gamma_guild")
 
 if __name__ == '__main__':
-    # working redshift creds, you can pass password as last parameter or via PASSWORD env variable ie.
-    # LOG_LEVEL=INFO PASSWORD=.... python examples/discord_iterator.py
+    # working redshift creds, you can pass password as last parameter or via PG__PASSWORD env variable ie.
+    # LOG_LEVEL=INFO PG__PASSWORD=.... python examples/discord_iterator.py
     credentials = PostgresPipelineCredentials("redshift", "chat_analytics_rasa", "gamma_guild_8", "loader", "3.73.90.3")
 
     pipeline = Pipeline("discord")

--- a/examples/ethereum.py
+++ b/examples/ethereum.py
@@ -1,3 +1,4 @@
+from hexbytes import HexBytes
 from dlt.common import Decimal
 from dlt.common.time import sleep
 from dlt.common.typing import DictStrAny
@@ -5,19 +6,254 @@ from dlt.pipeline import Pipeline, GCPPipelineCredentials
 from dlt.common.arithmetics import numeric_default_context, numeric_default_quantize
 
 from examples.schemas.ethereum import discover_schema
+from examples.sources.eth_source_utils import recode_tuples, flatten_batches, abi_to_selector, signature_to_abi
 from examples.sources.ethereum import get_source
 
-credentials = GCPPipelineCredentials.from_services_file("_secrets/project1234_service.json", "mainnet_6")
+# abi = signature_to_abi("event", "AxieggSpawned(uint256,uint256,uint256,uint256[],(uint256,uint256)[],(uint256,uint256))")
+# # abi = signature_to_abi("event", "AxieggSpawned(uint256,uint256,uint256,uint256,(uint256,uint256),(uint256,uint256))")
+# import pprint
+# pprint.pprint(abi)
+# assert abi_to_selector(abi) == HexBytes("0x280ad04291df39737839c19243929c95199e424e2518ea891b63deef3808bfe2")
+# exit(-1)
+# decoded = {
+#         "_tokenTypes": [
+#             1
+#         ],
+#         "_tokenAddresses": [
+#             "0x32950db2a7164aE833121501C797D79E7B79d74C"
+#         ],
+#         "_tokenNumbers": [
+#             11351913
+#         ],
+#         "_startingPrices": [
+#             40000000000000000
+#         ],
+#         "_endingPrices": [
+#             20000000000000000
+#         ],
+#         "_exchangeTokens": [
+#             "0xc99a6A985eD2Cac1ef41640596C5A5f9F4E19Ef5"
+#         ],
+#         "_durations": [
+#             432000
+#         ],
+#         "_dlt_meta": {
+#             "table_name": "Marketplace_calls_createAuction"
+#         },
+#         "_tx_blockNumber": 16039643,
+#         "_tx_blockTimestamp": 1659723680,
+#         "_tx_transactionHash": "\uf02a0x5714a265cf3456ad6bbacdf7a577f094f99b676bf19fde81153eea96fa224850",
+#         "_tx_transactionIndex": "0x0",
+#         "_tx_address": "0x213073989821f738A7BA3520C3D31a1F9aD31bBd",
+#         "_tx_status": "0x1"
+#     }
+
+# flatten_batches(decoded,
+# {
+#       "constant": False,
+#       "inputs": [
+#         {
+#           "internalType": "enum IExchange.TokenType[]",
+#           "name": "_tokenTypes",
+#           "type": "uint8[]"
+#         },
+#         {
+#           "internalType": "address[]",
+#           "name": "_tokenAddresses",
+#           "type": "address[]"
+#         },
+#         {
+#           "internalType": "uint256[]",
+#           "name": "_tokenNumbers",
+#           "type": "uint256[]"
+#         },
+#         {
+#           "internalType": "uint256[]",
+#           "name": "_startingPrices",
+#           "type": "uint256[]"
+#         },
+#         {
+#           "internalType": "uint256[]",
+#           "name": "_endingPrices",
+#           "type": "uint256[]"
+#         },
+#         {
+#           "internalType": "contract IERC20[]",
+#           "name": "_exchangeTokens",
+#           "type": "address[]"
+#         },
+#         {
+#           "internalType": "uint256[]",
+#           "name": "_durations",
+#           "type": "uint256[]"
+#         }
+#       ],
+#       "name": "createAuction",
+#       "outputs": [],
+#       "stateMutability": "nonpayable",
+#       "type": "function"
+#     })
+
+# import pprint
+# pprint.pprint(decoded)
+# exit(0)
+
+# decoded = {
+#         "param_0": 11403430,
+#         "param_1": [
+#             14474011154664526034909069339965131741826270611619044490146571011551995691272,
+#             [
+#                 1766959143701397048994461030926868181200402784820958467115499487534072066,
+#                 0,
+#                 "hah"
+#             ]
+#         ],
+#         "_dlt_meta": {
+#             "table_name": "AXIE_logs_AxieEvolved"
+#         },
+#         "_tx_blockNumber": 16039643,
+#         "_tx_blockTimestamp": 1659723680,
+#         "_tx_transactionHash": "\uf02a0x6302c20a4ef5426ee1da68fa3bdfb2c234a1f16fe441c51a35227ba4bd6746fa",
+#         "_tx_transactionIndex": "0x3",
+#         "_tx_address": "0x32950db2a7164aE833121501C797D79E7B79d74C",
+#         "_tx_status": "0x1",
+#         "_tx_logIndex": 15
+#     }
+# recode_tuples(decoded,
+#     {
+#       "name": "AxieEvolved",
+#       "type": "event",
+#       "inputs": [
+#         {
+#           "name": "param_0",
+#           "type": "uint256",
+#           "indexed": True
+#         },
+#         {
+#           "components": [
+#             {
+#               "name": "param_1_1",
+#               "type": "uint256"
+#             },
+#             {
+#               "name": "param_1_2",
+#               "type": "tuple",
+#               "components": [
+#                 {
+#                     "name": "param_deep_i",
+#                     "type": "uint256"
+#                 },
+#                 {
+#                     "name": "param_deep_2",
+#                     "type": "uint256"
+#                 },
+#                 {
+#                     "name": "param_deep_3",
+#                     "type": "string"
+#                 }
+#               ]
+#             }
+#           ],
+#           "name": "param_1",
+#           "type": "tuple",
+#           "indexed": False
+#         }
+#       ],
+#       "outputs": [],
+#       "anonymous": False,
+#       "_dlt_meta": {
+#         "selector": "0xa006fbbbc9600fe3b3757442d103355696bba0d2b8f9201852984b64d72a0a0b",
+#         "block": 16039643
+#       }
+#     }
+# )
+
+# import pprint
+# pprint.pprint(decoded)
+# exit(0)
+
+credentials = GCPPipelineCredentials.from_services_file("_secrets/project1234_service.json", "ronin_4")
 # credentials = PostgresPipelineCredentials("redshift", "chat_analytics_rasa", "mainnet_6", "loader", "3.73.90.3")
 
 pipeline = Pipeline("ethereum")
-pipeline.create_pipeline(credentials, schema=discover_schema())
-print(pipeline.root_path)
+
+# print(pipeline.root_path)
 
 # get ethereum source which is python iterator, request 3 newest blocks with default lag. also pass the state (optional)
 # so you can get newly produced blocks when the pipeline is run again
-i = get_source("https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161", 2, state=pipeline.state)
+# i = get_source("https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161", 2, state=pipeline.state)
 
+# from web3 import Web3
+# from web3._utils.abi import abi_to_signature
+# from web3.contract import ContractFunction
+# from examples.sources.eth_utils import signature_to_abi, decode_tx
+# from pprint import pprint
+# pprint(signature_to_abi("function", "AxieEvolved(uint256,(uint256,(uint256,string[]))[])"))
+# w3 = Web3()
+# pprint(decode_tx(w3, "0x70a88b27000000000000000000000000dd4ca6d2565aeabe0b469896141a23f9d3cb181100000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000011af00000000000000000000000000000000000000000000000000000000008467e7a03e101f2dec380e797fd683bae9f692d16aa07de900f720791539f474d8a4c8000000000000000000000000000000000000000000000000000001826f53c08000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000a8754b9fa15fc18bb59458815510e40a12cd2014000000000000000000000000c99a6a985ed2cac1ef41640596c5a5f9f4e19ef5"))
+
+# print(abi_to_signature({
+#     "name": "f",
+#     "type": "function",
+#     "inputs": [
+#       {
+#         "name": "s",
+#         "type": "tuple[]",
+#         "components": [
+#           {
+#             "name": "a",
+#             "type": "uint256"
+#           },
+#           {
+#             "name": "b",
+#             "type": "uint256[]"
+#           },
+#           {
+#             "name": "c",
+#             "type": "tuple[]",
+#             "components": [
+#               {
+#                 "name": "x",
+#                 "type": "uint256"
+#               },
+#               {
+#                 "name": "y",
+#                 "type": "uint256"
+#               }
+#             ]
+#           }
+#         ]
+#       },
+#       {
+#         "name": "t",
+#         "type": "tuple",
+#         "components": [
+#           {
+#             "name": "x",
+#             "type": "uint256"
+#           },
+#           {
+#             "name": "y",
+#             "type": "uint256"
+#           }
+#         ]
+#       },
+#       {
+#         "name": "a",
+#         "type": "uint256"
+#       }
+#     ],
+#     "outputs": ["uint256"]
+#   }))
+
+# exit(0)
+
+# "https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
+rpc_url = "https://api.roninchain.com/rpc"
+working_dir = "experiments/pipeline/ronin"
+abi_dir="experiments/data/ronin/abi"
+# pipeline.create_pipeline(credentials, schema=discover_schema(), working_dir=working_dir)
+# i = get_source(rpc_url, 4, abi_dir=abi_dir, is_poa=True, supports_batching=False, state=pipeline.state)
 
 # you can transform the blocks by defining mapping function
 def from_wei_to_eth(block: DictStrAny) -> DictStrAny:
@@ -35,18 +271,22 @@ def from_wei_to_eth(block: DictStrAny) -> DictStrAny:
 
 # extract data from the source. operation is atomic and like all atomic operations in pipeline, it does not raise but returns
 # execution status
-pipeline.extract(map(from_wei_to_eth, i), table_name="blocks")
-print(pipeline.state)
+# map(from_wei_to_eth, i)
+# pipeline.extract(i, table_name="blocks")
+# print(pipeline.state)
 
 # wait for ethereum network to produce some more blocks
-sleep(20)
+# sleep(20)
 
 # restore the pipeline from the working directory (simulate continuation from the saved state)
-pipeline.restore_pipeline(credentials, pipeline.root_path)
-# obtain new iterator (the old one is expired), this time use deferred iterator to allow parallel block reading
-i = get_source("https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161", 2, state=pipeline.state)
-pipeline.extract(map(from_wei_to_eth, i), table_name="blocks")
-print(pipeline.state)
+pipeline.restore_pipeline(credentials, working_dir)
+# while True:
+#     # obtain new iterator (the old one is expired), this time use deferred iterator to allow parallel block reading
+#     i = get_source(rpc_url, 8, abi_dir=abi_dir, is_poa=True, supports_batching=False, state=pipeline.state)
+#     pipeline.extract(i, table_name="blocks")
+#     sleep(10)
+# print(pipeline.state)
 
-# this will normalize and load all extracted data
-pipeline.flush()
+# this will unpack and load all extracted data
+pipeline.unpack()
+# pipeline.flush()

--- a/examples/ethereum.py
+++ b/examples/ethereum.py
@@ -288,5 +288,5 @@ pipeline.restore_pipeline(credentials, working_dir)
 # print(pipeline.state)
 
 # this will unpack and load all extracted data
-pipeline.unpack()
+pipeline.normalize()
 # pipeline.flush()

--- a/examples/read_table.py
+++ b/examples/read_table.py
@@ -8,7 +8,7 @@ from examples.sources.sql_query import get_source
 credentials = PostgresPipelineCredentials("redshift", "chat_analytics_rasa", "gamma_guild_7", "loader", "chat-analytics.czwteevq7bpe.eu-central-1.redshift.amazonaws.com")
 
 # create sql alchemy connector
-conn_str = f"redshift+redshift_connector://{credentials.USER}:{os.environ['PASSWORD']}@{credentials.HOST}:{credentials.PORT}/{credentials.DBNAME}"
+conn_str = f"redshift+redshift_connector://{credentials.USER}:{os.environ['PG__PASSWORD']}@{credentials.HOST}:{credentials.PORT}/{credentials.DBNAME}"
 
 # items = get_source("select *  from test_fixture_carbon_bot_session_cases_views.users limit 1", conn_str)
 

--- a/examples/schemas/ethereum_schema.yml
+++ b/examples/schemas/ethereum_schema.yml
@@ -49,7 +49,7 @@ tables:
         nullable: false
       base_fee_per_gas:
         data_type: wei
-        nullable: false
+        nullable: true
       difficulty:
         data_type: wei
         nullable: false
@@ -309,6 +309,10 @@ settings:
   preferred_types: {}
 normalizers:
   names: dlt.common.normalizers.names.snake_case
+  detections:
+    - timestamp
+    - large_integer
+    - hexbytes_text
   json:
     module: dlt.common.normalizers.json.relational
     config:

--- a/examples/schemas/ethereum_schema.yml
+++ b/examples/schemas/ethereum_schema.yml
@@ -312,7 +312,7 @@ normalizers:
   detections:
     - timestamp
     - large_integer
-    - hexbytes_text
+    - hexbytes_to_text
   json:
     module: dlt.common.normalizers.json.relational
     config:

--- a/examples/sources/eth_source_utils.py
+++ b/examples/sources/eth_source_utils.py
@@ -174,7 +174,7 @@ def decode_log(codec: ABIDecoder, abi: ABIEvent, log: LogReceipt) -> EventData:
         log (LogReceipt): raw log data
 
     Raises:
-        ValueError: DecodeError or ValueError if no right combination of indexes could not be found
+        ValueError: DecodeError or ValueError if no right combination of indexes could be found
 
     Returns:
         EventData: Decoded data

--- a/examples/sources/eth_source_utils.py
+++ b/examples/sources/eth_source_utils.py
@@ -166,6 +166,21 @@ def decode_tx(codec: ABIDecoder, abi: ABIFunction, params: HexBytes) -> DictStrA
 
 
 def decode_log(codec: ABIDecoder, abi: ABIEvent, log: LogReceipt) -> EventData:
+    """Decodes raw log data using provided ABI. In case of missing indexes it will figure out the right combination by trying out all possibilities
+
+    Args:
+        codec (ABIDecoder): ABI decoder
+        abi (ABIEvent): ABI of the event
+        log (LogReceipt): raw log data
+
+    Raises:
+        ValueError: DecodeError or ValueError if no right combination of indexes could not be found
+
+    Returns:
+        EventData: Decoded data
+
+        Will also add/remove indexes in `abi`
+    """
     log_topics = log["topics"][1:]
     log_topics_abi = get_indexed_event_inputs(abi)
     log_topic_normalized_inputs = normalize_event_input_types(log_topics_abi)
@@ -182,6 +197,7 @@ def decode_log(codec: ABIDecoder, abi: ABIEvent, log: LogReceipt) -> EventData:
 
             try:
                 print(abi)
+                # codec detects the incorrect padding, for example it does not allow any other byte to be set for uint8, just the LSB
                 rv: EventData = get_event_data(codec, abi, log)
                 print("recovered indexes in abi: ")
                 print(abi)

--- a/examples/sources/eth_source_utils.py
+++ b/examples/sources/eth_source_utils.py
@@ -90,11 +90,10 @@ def maybe_update_abi(abi_info: TABIInfo, selector: HexBytes, new_abi: ABIElement
 
 
 def signature_to_abi(sig_type: str, sig: str) -> ABIElement:
-    # get name
+    # get name and pass remainder for tokenization
     name, remainder = sig.split("(", maxsplit=1)
-    # assert remainder[-1] == ")"
-    # remainder = remainder[:-1]
 
+    # simple tokenizer that yields "(" ")" "," and tokens between them. empty tokens are ignored
     def tokens() -> Iterator[str]:
         start = 0
         pos = 0
@@ -105,19 +104,10 @@ def signature_to_abi(sig_type: str, sig: str) -> ABIElement:
                     yield remainder[start:pos].strip()
                 yield char
                 start = pos = pos + 1
-            # elif char in [","]:
-            #     # assert pos - start > 0:
-            #     if pos - start > 0:
-            #         yield remainder[start:pos].strip()
-            #     # yield remainder[start:pos]
-            #     start = pos = pos + 1
             else:
                 # move to next "," and return token
                 pos += 1
 
-    print(list(tokens()))
-
-    # types = re.split("[,()]", remainder)
     tokens_gen = tokens()
 
     abi: ABIElement = {
@@ -127,13 +117,12 @@ def signature_to_abi(sig_type: str, sig: str) -> ABIElement:
         "outputs": []
     }
 
-    def _to_components(inputs: List[ABIFunctionComponents], param: str) -> str:
+    def _to_components(inputs: List[ABIFunctionComponents], param: str) -> None:
         typ_: str = None
         input_def: ABIFunctionParams = {}
         i = 0
 
         while tok := next(tokens_gen):
-            print(tok)
             if tok == "(":
                 # step into component parsing
                 # tok = tok[1:]
@@ -145,18 +134,19 @@ def signature_to_abi(sig_type: str, sig: str) -> ABIElement:
                 assert typ_ is not None
                 typ_ += tok
             elif tok in [")",","]:
-                # up from component parsing
+                # add current type
                 assert typ_ is not None
-                print(input_def)
                 input_def.update({
                     "name": f"{param}_{i}",
                     "type": typ_
                 })
                 inputs.append(input_def)
                 if tok == ")":
+                    # up from component parsing
                     return
                 else:
-                    input_def: ABIFunctionParams = {}
+                    # prepare for new type
+                    input_def = {}
                     typ_ = None
                     i += 1
             else:
@@ -185,10 +175,10 @@ def decode_log(codec: ABIDecoder, abi: ABIEvent, log: LogReceipt) -> EventData:
         # we have incorrect information on topic indexes in abi so we'll recursively try to discover the right combination
         for indexed_inputs in itertools.combinations(abi["inputs"], len(log_topics)):
             print(f"attempt recursive decoding for {log['topics'][0].hex()}")
-            for input in abi["inputs"]:
-                input["indexed"] = False
-            for input in indexed_inputs:
-                input["indexed"] = True
+            for input_ in abi["inputs"]:
+                input_["indexed"] = False
+            for input_ in indexed_inputs:
+                input_["indexed"] = True
 
             try:
                 print(abi)
@@ -196,7 +186,7 @@ def decode_log(codec: ABIDecoder, abi: ABIEvent, log: LogReceipt) -> EventData:
                 print("recovered indexes in abi: ")
                 print(abi)
                 return rv
-            except DecodingError as exc:
+            except DecodingError:
                 pass
 
             raise ValueError("None of the indexed topic combinations decoded correctly")
@@ -225,8 +215,8 @@ def fetch_sig_and_decode_log(codec: ABIDecoder, log: LogReceipt) -> Tuple[str, E
         abi = cast(ABIEvent, signature_to_abi("event", sig_name))
         assert abi_to_selector(abi) == topic
         abi["anonymous"] = False
-        for input in abi["inputs"]:
-            input.setdefault("indexed", False)
+        for input_ in abi["inputs"]:
+            input_.setdefault("indexed", False)
 
         try:
             return sig_name, decode_log(codec, abi, log), abi
@@ -248,7 +238,7 @@ def fetch_sig_and_decode_tx(codec: ABIDecoder, tx_input: HexBytes) -> Tuple[str,
         try:
             return sig_name, abi["name"], decode_tx(codec, abi, params), abi
         except DecodingError as ex:
-            print("Could not be decoded")
+            print(f"Could not be decoded {ex}")
             continue
 
     # no known signatures or nothing could be decoded
@@ -264,13 +254,13 @@ def prettify_decoded(decoded: DictStrAny, abi: ABIElement) -> DictStrAny:
 
 def flatten_batches(decoded: DictStrAny, abi: ABIElement) -> None:
     batch = []
-    for input in abi["inputs"]:
+    for input_ in abi["inputs"]:
         prev_len: int = None
-        decoded_val = decoded.get(input["name"])
+        decoded_val = decoded.get(input_["name"])
         if decoded_val is not None:
             if isinstance(decoded_val, Sequence):
                 if prev_len is None or prev_len == len(decoded_val):
-                    batch.append(input["name"])
+                    batch.append(input_["name"])
                     prev_len = len(decoded_val)
                 else:
                     # list length not equal so this is not a batch
@@ -287,16 +277,16 @@ def flatten_batches(decoded: DictStrAny, abi: ABIElement) -> None:
 def recode_tuples(decoded: DictStrAny, abi: ABIElement) -> None:
     # replaces lists with dicts representing named tuples
 
-    def _replace_component(decoded_component: Sequence[Any], inputs: Sequence[ABIFunctionComponents]):
+    def _replace_component(decoded_component: Sequence[Any], inputs: Sequence[ABIFunctionComponents]) -> Dict[str, Any]:
         for idx, i_i in enumerate(zip(decoded_component, inputs)):
-            item, input = i_i
-            if input["type"] == "tuple" and isinstance(item, Sequence):
-                recoded = _replace_component(item, input["components"])
+            item, input_ = i_i
+            if input_["type"] == "tuple" and isinstance(item, Sequence):
+                recoded = _replace_component(item, input_["components"])
                 decoded_component[idx] = recoded  # type: ignore
-        return {input["name"]:item for item, input in zip(decoded_component, inputs)}
+        return {input_["name"]:item for item, input_ in zip(decoded_component, inputs)}
 
-    input: ABIFunctionParams = None
-    for input in abi["inputs"]:
-        decoded_val = decoded.get(input["name"])
-        if input["type"] == "tuple" and isinstance(decoded_val, Sequence):
-            decoded[input["name"]] = _replace_component(decoded_val, input["components"])
+    input_: ABIFunctionParams = None
+    for input_ in abi["inputs"]:  # type: ignore
+        decoded_val = decoded.get(input_["name"])
+        if input_["type"] == "tuple" and isinstance(decoded_val, Sequence):
+            decoded[input_["name"]] = _replace_component(decoded_val, input_["components"])

--- a/examples/sources/eth_source_utils.py
+++ b/examples/sources/eth_source_utils.py
@@ -1,0 +1,302 @@
+import os
+import re
+import itertools
+from textwrap import indent
+from hexbytes import HexBytes
+import requests
+from typing import Any, Dict, Iterable, Iterator, List, Sequence, Type, TypedDict, Tuple, cast
+
+from web3 import Web3
+from web3.types import ABI, ABIElement, ABIFunction, ABIEvent, ABIFunctionParams, ABIFunctionComponents, LogReceipt, EventData
+from web3._utils.abi import get_abi_input_names, get_abi_input_types, map_abi_data, get_indexed_event_inputs, normalize_event_input_types
+from web3._utils.normalizers import BASE_RETURN_NORMALIZERS
+from web3._utils.events import get_event_data, get_event_abi_types_for_decoding
+from eth_typing import HexStr
+from eth_typing.evm import ChecksumAddress
+from eth_abi.codec import ABIDecoder
+from eth_abi.exceptions import DecodingError
+from eth_utils.abi import function_abi_to_4byte_selector, event_abi_to_log_topic
+
+from dlt.common import json
+from dlt.common.typing import DictStrAny, StrAny, StrStr
+
+
+class TABIInfo(TypedDict):
+    name: str
+    abi_file: str
+    abi: ABI
+    unknown_selectors: DictStrAny
+    file_content: StrAny
+    selectors: Dict[HexBytes, ABIElement]
+
+
+class EthSigItem(TypedDict):
+    name: str
+    filtered: bool
+
+
+def abi_to_selector(abi: ABIElement) -> HexBytes:
+    if abi["type"] == "event":
+        return HexBytes(event_abi_to_log_topic(abi))  # type: ignore
+    elif abi["type"] == "function":
+        return HexBytes(function_abi_to_4byte_selector(abi))  # type: ignore
+    else:
+        raise ValueError(abi)
+
+
+def load_abis(w3: Web3, abi_dir: str) -> Dict[ChecksumAddress, TABIInfo]:
+    contracts: Dict[ChecksumAddress, TABIInfo] = {}
+    if abi_dir:
+        for abi_file in os.scandir(abi_dir):
+            if not abi_file.is_file():
+                continue
+            address  = w3.toChecksumAddress(os.path.basename(abi_file).split(".")[0])
+            with open(abi_file, mode="r", encoding="utf-8") as f:
+                abi: DictStrAny = json.load(f)
+                # print(f"adding contract {abi['name']} with address {address}")
+                contracts[address] = {
+                    "name": abi['name'],
+                    "abi": abi["abi"],
+                    "abi_file": abi_file.name,
+                    "unknown_selectors": abi.setdefault("unknown_selectors", {}),
+                    "file_content": abi,
+                    "selectors": {abi_to_selector(a):a for a in abi["abi"] if a["type"] in ["function", "event"]}
+                }
+    return contracts
+
+
+def save_abis(abi_dir: str, abis: Iterable[TABIInfo]) -> None:
+    if abi_dir:
+        for abi in abis:
+            save_path = os.path.join(abi_dir, abi["abi_file"])
+            # print(f"saving {save_path}")
+            with open(save_path, mode="w", encoding="utf-8") as f:
+                json.dump(abi["file_content"], f, indent=2)
+
+
+def maybe_update_abi(abi_info: TABIInfo, selector: HexBytes, new_abi: ABIElement, in_block: int) -> None:
+    add_info = {
+        "selector": selector.hex(),
+        "block": in_block
+    }
+    if not new_abi:
+        abi_info["unknown_selectors"][selector.hex()] = add_info
+        print(f"could not be found or decoded: {add_info}")
+    else:
+        print(f"found and decoded {add_info} to {new_abi['name']}")
+        new_abi["_dlt_meta"] = add_info  # type: ignore
+        abi_info["abi"].append(new_abi)  # type: ignore
+        abi_info["selectors"][selector] = new_abi
+
+
+def signature_to_abi(sig_type: str, sig: str) -> ABIElement:
+    # get name
+    name, remainder = sig.split("(", maxsplit=1)
+    # assert remainder[-1] == ")"
+    # remainder = remainder[:-1]
+
+    def tokens() -> Iterator[str]:
+        start = 0
+        pos = 0
+        while pos < len(remainder):
+            char = remainder[pos]
+            if char in ["(", ")",","]:
+                if pos - start > 0:
+                    yield remainder[start:pos].strip()
+                yield char
+                start = pos = pos + 1
+            # elif char in [","]:
+            #     # assert pos - start > 0:
+            #     if pos - start > 0:
+            #         yield remainder[start:pos].strip()
+            #     # yield remainder[start:pos]
+            #     start = pos = pos + 1
+            else:
+                # move to next "," and return token
+                pos += 1
+
+    print(list(tokens()))
+
+    # types = re.split("[,()]", remainder)
+    tokens_gen = tokens()
+
+    abi: ABIElement = {
+        "name": name,
+        "type": sig_type,  # type: ignore
+        "inputs": [],
+        "outputs": []
+    }
+
+    def _to_components(inputs: List[ABIFunctionComponents], param: str) -> str:
+        typ_: str = None
+        input_def: ABIFunctionParams = {}
+        i = 0
+
+        while tok := next(tokens_gen):
+            print(tok)
+            if tok == "(":
+                # step into component parsing
+                # tok = tok[1:]
+                input_def["components"] = []
+                _to_components(input_def["components"], f"{param}_{i}")  # type: ignore
+                typ_ = "tuple"
+            elif tok == "[]":
+                # mod last typ_ to be array
+                assert typ_ is not None
+                typ_ += tok
+            elif tok in [")",","]:
+                # up from component parsing
+                assert typ_ is not None
+                print(input_def)
+                input_def.update({
+                    "name": f"{param}_{i}",
+                    "type": typ_
+                })
+                inputs.append(input_def)
+                if tok == ")":
+                    return
+                else:
+                    input_def: ABIFunctionParams = {}
+                    typ_ = None
+                    i += 1
+            else:
+                typ_ = tok
+    _to_components(abi["inputs"], "param")  # type: ignore
+
+    return abi
+
+
+def decode_tx(codec: ABIDecoder, abi: ABIFunction, params: HexBytes) -> DictStrAny:
+    names = get_abi_input_names(abi)
+    types = get_abi_input_types(abi)
+    decoded = codec.decode_abi(types, params)
+    normalized = map_abi_data(BASE_RETURN_NORMALIZERS, types, decoded)
+
+    return dict(zip(names, normalized))
+
+
+def decode_log(codec: ABIDecoder, abi: ABIEvent, log: LogReceipt) -> EventData:
+    log_topics = log["topics"][1:]
+    log_topics_abi = get_indexed_event_inputs(abi)
+    log_topic_normalized_inputs = normalize_event_input_types(log_topics_abi)
+    log_topic_types = get_event_abi_types_for_decoding(log_topic_normalized_inputs)
+
+    if len(log_topics) != len(log_topic_types):
+        # we have incorrect information on topic indexes in abi so we'll recursively try to discover the right combination
+        for indexed_inputs in itertools.combinations(abi["inputs"], len(log_topics)):
+            print(f"attempt recursive decoding for {log['topics'][0].hex()}")
+            for input in abi["inputs"]:
+                input["indexed"] = False
+            for input in indexed_inputs:
+                input["indexed"] = True
+
+            try:
+                print(abi)
+                rv: EventData = get_event_data(codec, abi, log)
+                print("recovered indexes in abi: ")
+                print(abi)
+                return rv
+            except DecodingError as exc:
+                pass
+
+            raise ValueError("None of the indexed topic combinations decoded correctly")
+
+    return cast(EventData, get_event_data(codec, abi, log))
+
+
+def fetch_sig(sig_type: str, selector: HexStr) -> Sequence[EthSigItem]:
+    r = requests.get(f"https://sig.eth.samczsun.com/api/v1/signatures?{sig_type}={selector}")
+    if r.status_code >= 300:
+        print(f"{selector} is not known at sig.eth.samczsun.com")
+        r.raise_for_status()
+    resp = r.json()
+    if not resp["ok"]:
+        print(f"{selector} is not OK at sig.eth.samczsun.com")
+        r.raise_for_status()
+
+    return resp["result"][sig_type][selector]  # type: ignore
+
+
+def fetch_sig_and_decode_log(codec: ABIDecoder, log: LogReceipt) -> Tuple[str, EventData, ABIEvent]:
+    topic = log["topic"]
+
+    for sig in fetch_sig("event", HexStr(topic.hex())):
+        sig_name: str = sig["name"]
+        abi = cast(ABIEvent, signature_to_abi("event", sig_name))
+        assert abi_to_selector(abi) == topic
+        abi["anonymous"] = False
+        for input in abi["inputs"]:
+            input.setdefault("indexed", False)
+
+        try:
+            return sig_name, decode_log(codec, abi, log), abi
+        except DecodingError:
+            print("Could not be decoded")
+            continue
+
+    # no known signatures or nothing could be decoded
+    return None, None, None
+
+
+def fetch_sig_and_decode_tx(codec: ABIDecoder, tx_input: HexBytes) -> Tuple[str, str, DictStrAny, ABIFunction]:
+    selector, params = tx_input[:4], tx_input[4:]
+
+    for sig in fetch_sig("function", HexStr(selector.hex())):
+        sig_name: str = sig["name"]
+        abi = cast(ABIFunction, signature_to_abi("function", sig_name))
+        assert abi_to_selector(abi) == selector
+        try:
+            return sig_name, abi["name"], decode_tx(codec, abi, params), abi
+        except DecodingError as ex:
+            print("Could not be decoded")
+            continue
+
+    # no known signatures or nothing could be decoded
+    return None, None, None, None
+
+
+def prettify_decoded(decoded: DictStrAny, abi: ABIElement) -> DictStrAny:
+    # TODO: detect ERC20 and format decimals properly
+    recode_tuples(decoded, abi)
+    flatten_batches(decoded, abi)
+    return decoded
+
+
+def flatten_batches(decoded: DictStrAny, abi: ABIElement) -> None:
+    batch = []
+    for input in abi["inputs"]:
+        prev_len: int = None
+        decoded_val = decoded.get(input["name"])
+        if decoded_val is not None:
+            if isinstance(decoded_val, Sequence):
+                if prev_len is None or prev_len == len(decoded_val):
+                    batch.append(input["name"])
+                    prev_len = len(decoded_val)
+                else:
+                    # list length not equal so this is not a batch
+                    return
+            else:
+                # not all elements are lists so this is not a batch
+                return
+
+    decoded["batch"] = [{n:decoded[n][i] for n in batch} for i in range(prev_len)]
+    for n in batch:
+        del decoded[n]
+
+
+def recode_tuples(decoded: DictStrAny, abi: ABIElement) -> None:
+    # replaces lists with dicts representing named tuples
+
+    def _replace_component(decoded_component: Sequence[Any], inputs: Sequence[ABIFunctionComponents]):
+        for idx, i_i in enumerate(zip(decoded_component, inputs)):
+            item, input = i_i
+            if input["type"] == "tuple" and isinstance(item, Sequence):
+                recoded = _replace_component(item, input["components"])
+                decoded_component[idx] = recoded  # type: ignore
+        return {input["name"]:item for item, input in zip(decoded_component, inputs)}
+
+    input: ABIFunctionParams = None
+    for input in abi["inputs"]:
+        decoded_val = decoded.get(input["name"])
+        if input["type"] == "tuple" and isinstance(decoded_val, Sequence):
+            decoded[input["name"]] = _replace_component(decoded_val, input["components"])

--- a/examples/sources/ethereum.py
+++ b/examples/sources/ethereum.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterator, List, Tuple, Type, TypedDict, Union, cast, Sequence
+from typing import Any, Callable, Dict, Iterator, List, Tuple, Type, TypedDict, Union, cast, Sequence
 from hexbytes import HexBytes
 import requests
 
@@ -68,7 +68,7 @@ def _get_source(is_deferred: bool, node_url: str, no_blocks: int, last_block: in
 
     assert current_block >= 0
     if current_block > last_block:
-        print(f"Nothing to do")
+        print("Nothing to do")
         return
 
     # get chain id
@@ -133,7 +133,7 @@ def _get_block(w3: Web3, current_block: int, chain_id: int, supports_batching: b
     block["logsBloom"] = bytes(cast(HexBytes, block["logsBloom"]))  # serialize as bytes
 
     receipts = []
-    log_formatters = get_result_formatters(RPC.eth_getLogs, w3.eth)
+    log_formatters: Callable[..., Any] = get_result_formatters(RPC.eth_getLogs, w3.eth)  # type: ignore
     provider = cast(HTTPProvider, w3.provider)
     rpc_endpoint_url = provider.endpoint_uri
     if supports_batching:

--- a/examples/sources/ethereum.py
+++ b/examples/sources/ethereum.py
@@ -1,15 +1,23 @@
-from typing import Any, Iterator, Union, cast, Sequence
+from typing import Any, Dict, Iterator, List, Tuple, Type, TypedDict, Union, cast, Sequence
 from hexbytes import HexBytes
 import requests
 
-from dlt.common.typing import DictStrAny
-from dlt.common.sources import TDeferred, TItem, defer_iterator, with_retry
+from dlt.common.typing import DictStrAny, StrAny
+from dlt.common.sources import TDeferred, TItem, defer_iterator, with_retry, with_table_name
 
 from dlt.pipeline.exceptions import MissingDependencyException
+from examples.sources.eth_source_utils import decode_log, decode_tx, fetch_sig_and_decode_log, fetch_sig_and_decode_tx, maybe_update_abi, prettify_decoded, save_abis
 
 try:
     # import gracefully and produce nice exception that explains the user what to do
     from web3 import Web3, HTTPProvider
+    from web3.middleware import geth_poa_middleware
+    from eth_typing.evm import ChecksumAddress
+    from web3._utils.method_formatters import get_result_formatters
+    from web3._utils.rpc_abi import RPC
+    from web3.types import LogReceipt, EventData, ABIEvent
+
+    from examples.sources.eth_source_utils import load_abis, TABIInfo, ABIFunction
 except ImportError:
     raise MissingDependencyException("Ethereum Source", ["web3"], "Web3 is a all purpose python library to interact with Ethereum-compatible blockchains.")
 
@@ -21,18 +29,27 @@ except ImportError:
 # - the return value is iterator (or deferred iterator) so still mappings may be used (ie. to decode transactions and logs), see example
 
 
-def get_source(node_url: str, no_blocks: int, last_block: int = None, lag: int = 2, state: DictStrAny = None) -> Iterator[DictStrAny]:
-    return _get_source(False, node_url, no_blocks, last_block, lag, state)  # type: ignore
+def get_source(node_url: str, no_blocks: int, last_block: int = None, abi_dir: str = None, lag: int = 2, is_poa: bool = False, supports_batching: bool = True, state: DictStrAny = None) -> Iterator[DictStrAny]:
+    return _get_source(False, node_url, no_blocks, last_block, abi_dir, lag, is_poa, supports_batching, state)  # type: ignore
 
 
-def get_deferred_source(node_url: str, no_blocks: int, last_block: int = None, lag: int = 2, state: DictStrAny = None) -> Iterator[TDeferred[DictStrAny]]:
-    return _get_source(True, node_url, no_blocks, last_block, lag, state)  # type: ignore
+def get_deferred_source(node_url: str, no_blocks: int, last_block: int = None, abi_dir: str = None, lag: int = 2, is_poa: bool = False, supports_batching: bool = True, state: DictStrAny = None) -> Iterator[TDeferred[DictStrAny]]:
+    return _get_source(True, node_url, no_blocks, last_block, abi_dir, lag, is_poa, supports_batching, state)  # type: ignore
 
 
-def _get_source(is_deferred: bool, node_url: str, no_blocks: int, last_block: int, lag: int, state: DictStrAny = None) -> Union[Iterator[TItem], Iterator[TDeferred[DictStrAny]]]:
+def _get_source(is_deferred: bool, node_url: str, no_blocks: int, last_block: int, abi_dir: str, lag: int, is_poa: bool, supports_batching: bool, state: DictStrAny = None) -> Union[Iterator[TItem], Iterator[TDeferred[DictStrAny]]]:
 
     # this code is run only once
-    w3 = Web3(Web3.HTTPProvider(node_url))
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36"
+    }
+    w3 = Web3(Web3.HTTPProvider(node_url, request_kwargs={"headers": headers}))
+    if is_poa:
+        w3.middleware_onion.inject(geth_poa_middleware, layer=0)
+
+    # load abis from abi_dir
+    contracts = load_abis(w3, abi_dir)
 
     # last block is not provided then take the highest block from the chain
     if last_block is None:
@@ -45,9 +62,14 @@ def _get_source(is_deferred: bool, node_url: str, no_blocks: int, last_block: in
     # get current block from the state if available
     if state:
         current_block = state.get("ethereum_current_block", current_block)
+        print(f"Will continue from {current_block} to {last_block}")
+    else:
+        print(f"Will start from {current_block} to {last_block}")
 
     assert current_block >= 0
-    assert current_block <= last_block
+    if current_block > last_block:
+        print(f"Nothing to do")
+        return
 
     # get chain id
     chain_id = w3.eth.chain_id
@@ -60,29 +82,36 @@ def _get_source(is_deferred: bool, node_url: str, no_blocks: int, last_block: in
         @defer_iterator
         @with_retry()
         def _get_block_deferred() -> DictStrAny:
-            return _get_block(w3, current_block, chain_id)
+            return _get_block(w3, current_block, chain_id, supports_batching)
 
         @with_retry()
         def _get_block_retry() -> DictStrAny:
-            return _get_block(w3, current_block, chain_id)
+            return _get_block(w3, current_block, chain_id, supports_batching)
 
         # yield deferred items or actual item values
         if is_deferred:
             yield _get_block_deferred()
         else:
-            yield _get_block_retry()
+            block = _get_block_retry()
+            yield block
+            yield from _decode_block(w3, block, contracts)
         current_block += 1
 
     # update state, it will be read and stored with the pipeline instance ONLY when whole iterator finishes
     # state participates in the same atomic operation as data
     # this must happen after last yield
     print(f"finalizing {state}")
+    save_abis(abi_dir, contracts.values())
     if state is not None:
         state["ethereum_current_block"] = current_block
 
 
-def _get_block(w3: Web3, current_block: int, chain_id: int) -> DictStrAny:
+def _get_block(w3: Web3, current_block: int, chain_id: int, supports_batching: bool) -> DictStrAny:
     print(f"producing block {current_block}")
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36"
+    }
 
     # get block with all transaction
     block = dict(w3.eth.get_block(current_block, full_transactions=True))
@@ -91,45 +120,119 @@ def _get_block(w3: Web3, current_block: int, chain_id: int) -> DictStrAny:
     # get rid of AttributeDict (web3 didn't adopt TypedDict)
     attr_txs = cast(Sequence[Any], block["transactions"])
     transactions: Sequence[DictStrAny] = [dict(tx) for tx in attr_txs]
+    # maybe_unknown_inputs: List[str] = []
     for tx in transactions:
         if "accessList" in tx and len(tx["accessList"]) > 0:
             tx["accessList"] = [dict(al) for al in tx["accessList"]]
-        # propagate sorting and clustering info (we could also do it in normalize: TODO:!)
-        tx["block_timestamp"] = block["timestamp"]
-
+        # propagate sorting and clustering info (we could also do it in unpacker: TODO:!)
+        tx["blockTimestamp"] = block["timestamp"]
         # overwrite chain_id which is not provided in all cases
         tx["chainId"] = chain_id
 
     block["transactions"] = transactions
     block["logsBloom"] = bytes(cast(HexBytes, block["logsBloom"]))  # serialize as bytes
 
-    # get transaction receipts using batching. web3 does not support batching so we must
-    # call node directly and then convert hex numbers to ints
-    batch = []
-    for idx, tx in enumerate(transactions):
-        batch.append({
-            "jsonrpc": "2.0",
-            "method": "eth_getTransactionReceipt",
-            "params": [tx["hash"]],
-            "id": idx
-        })
+    receipts = []
+    log_formatters = get_result_formatters(RPC.eth_getLogs, w3.eth)
     provider = cast(HTTPProvider, w3.provider)
-    r = requests.post(provider.endpoint_uri, json=batch, timeout=(20, 12))
-    r.raise_for_status()
-    receipts = r.json()
+    rpc_endpoint_url = provider.endpoint_uri
+    if supports_batching:
+        # get transaction receipts using batching. web3 does not support batching so we must
+        # call node directly and then convert hex numbers to ints
+        batch = []
+        for idx, tx in enumerate(transactions):
+            batch.append({
+                "jsonrpc": "2.0",
+                "method": "eth_getTransactionReceipt",
+                "params": [tx["hash"]],
+                "id": idx
+            })
+
+        r = requests.post(rpc_endpoint_url, json=batch, timeout=(20, 12), headers=headers)
+        r.raise_for_status()
+        receipts = r.json()
+    else:
+        for idx, tx in enumerate(transactions):
+            r = requests.post(rpc_endpoint_url, json={
+                "jsonrpc": "2.0",
+                "method": "eth_getTransactionReceipt",
+                "params": [tx["hash"]],
+                "id": idx
+            }, timeout=(20, 12), headers=headers)
+            r.raise_for_status()
+            receipts.append(r.json())
     for tx_receipt, tx in zip(receipts, transactions):
         if "result" not in tx_receipt:
             raise ValueError(tx_receipt)
         tx_receipt = tx_receipt["result"]
         assert tx_receipt["transactionHash"] == tx["hash"].hex()
-        tx["transactionIndex"] = Web3.toInt(hexstr=tx_receipt["transactionIndex"])
-        tx["status"] = Web3.toInt(hexstr=tx_receipt["status"])
-        tx["logs"] = tx_receipt["logs"]
-        for log in tx_receipt["logs"]:
-            log["blockNumber"] = Web3.toInt(hexstr=log["blockNumber"])
-            log["transactionIndex"] = Web3.toInt(hexstr=log["transactionIndex"])
-            log["logIndex"] = Web3.toInt(hexstr=log["logIndex"])
-            log["block_timestamp"] = block["timestamp"]
-            log["block_hash"] = block["hash"]
+        tx["transactionIndex"] = tx_receipt["transactionIndex"]
+        tx["status"] = tx_receipt["status"]
+        tx["logs"] = [dict(log) for log in log_formatters(tx_receipt["logs"])]
+        log: LogReceipt = None
+        for log in tx["logs"]:
+            log["topic"] = log["topics"][0]
+            # log["blockHash"] = block["hash"]
 
     return block
+
+
+def _decode_block(w3: Web3, block: StrAny, contracts: Dict[ChecksumAddress, TABIInfo]) -> Iterator[StrAny]:
+    transactions: Sequence[Any] = block["transactions"]
+    for tx in transactions:
+        tx_info = {
+            "_tx_blockNumber": tx["blockNumber"],
+            "_tx_blockTimestamp": tx["blockTimestamp"],
+            "_tx_transactionHash": tx["hash"],
+            "_tx_transactionIndex": tx["transactionIndex"],
+            "_tx_address": tx["to"],
+            "_tx_status": tx["status"]
+        }
+        # decode transaction
+        if tx["to"] in contracts:
+            abi_info = contracts[tx["to"]]
+            tx_input = HexBytes(tx["input"])
+            selector = tx_input[:4]
+            tx_abi = cast(ABIFunction, abi_info["selectors"].get(selector))
+            tx_args: DictStrAny = None
+            fn_name: str = None
+
+            if tx_abi:
+                tx_args = decode_tx(w3.codec, tx_abi, tx_input[4:])
+                fn_name = tx_abi["name"]
+            else:
+                if abi_info["unknown_selectors"].get(selector.hex()) is None:
+                    # try to decode with an api
+                    sig, fn_name, tx_args, tx_abi = fetch_sig_and_decode_tx(w3.codec, tx_input)
+                    maybe_update_abi(abi_info, selector, tx_abi, block["number"])
+
+            if tx_args:
+                tx_args =  with_table_name(tx_args, abi_info["name"] + "_calls_" + fn_name)
+                # yield arguments with reference to transaction
+                tx_args.update(tx_info)
+                yield prettify_decoded(tx_args, tx_abi)
+
+        # decode logs
+        log: LogReceipt
+        for log in tx["logs"]:
+            if log["address"] in contracts:
+                abi_info = contracts[log["address"]]
+                selector = log["topic"]
+                event_abi = cast(ABIEvent, abi_info["selectors"].get(selector))
+                event_data: EventData = None
+                if event_abi:
+                    event_data = decode_log(w3.codec, event_abi, log)
+                else:
+                    if abi_info["unknown_selectors"].get(selector.hex()) is None:
+                        # try to decode with an api
+                        sig, event_data, event_abi = fetch_sig_and_decode_log(w3.codec, log)
+                        maybe_update_abi(abi_info, selector, event_abi, block["number"])
+
+                if event_data:
+                    ev_args =  with_table_name(dict(event_data["args"]), abi_info["name"] + "_logs_" + event_data["event"])
+                    # yield arguments with reference to transaction and log
+                    ev_args.update(tx_info)
+                    ev_args.update({
+                        "_tx_logIndex": event_data["logIndex"]
+                    })
+                    yield prettify_decoded(ev_args, event_abi)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1330,6 +1330,14 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "tomlkit"
+version = "0.11.3"
+description = "Style preserving TOML library"
+category = "main"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[[package]]
 name = "types-cachetools"
 version = "4.2.10"
 description = "Typing stubs for cachetools"
@@ -1450,7 +1458,7 @@ redshift = ["psycopg2-binary"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.11"
-content-hash = "d63ff982a91d006f55782e5ca026932f87a870d63156335f1f3a62063959d2d8"
+content-hash = "11e680ca7b04ac6a81bbcdaa0de674c117636db96f46cda91f462bae30516749"
 
 [metadata.files]
 agate = [
@@ -2366,6 +2374,7 @@ tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
+tomlkit = []
 types-cachetools = [
     {file = "types-cachetools-4.2.10.tar.gz", hash = "sha256:b1cb18aaff25d2ad47a060413c660c39fadddb01f72012dd1134584b1fdaada5"},
     {file = "types_cachetools-4.2.10-py3-none-any.whl", hash = "sha256:48301115189d4879d0960baac5a8a2b2d31ce6129b2ce3b915000ed337284898"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dbt-redshift = {version = "1.0.1", optional = true}
 dbt-bigquery = {version = "1.0.0", optional = true}
 randomname = "^0.1.5"
 tzdata = "^2022.1"
+tomlkit = "^0.11.3"
 
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python-dlt"
-version = "0.1.0rc10"
+version = "0.1.0rc11"
 description = "DLT is an open-source python-native scalable data loading framework that does not require any devops efforts to run."
 authors = ["ScaleVector <services@scalevector.ai>"]
 maintainers = [ "Marcin Rudolf <marcin@scalevector.ai>", "Adrian Brudaru <adrian@scalevector.ai>",]

--- a/tests/.example.env
+++ b/tests/.example.env
@@ -4,14 +4,14 @@
 
 DEFAULT_DATASET=carbon_bot_3
 
-PROJECT_ID=chat-analytics-317513
-PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
+GCP__PROJECT_ID=chat-analytics-317513
+GCP__PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
     paste key here
     -----END PRIVATE KEY-----
 "
 CLIENT_EMAIL=loader@chat-analytics-317513.iam.gserviceaccount.com
 
-DBNAME=chat_analytics_rasa
-USER=loader
-HOST=3.73.90.3
-PASSWORD=set-me-up
+PG__DBNAME=chat_analytics_rasa
+PG__USER=loader
+PG__HOST=3.73.90.3
+PG__PASSWORD=set-me-up

--- a/tests/common/schema/test_coercion.py
+++ b/tests/common/schema/test_coercion.py
@@ -12,7 +12,7 @@ def test_coerce_type_others() -> None:
     # anything into text
     assert utils.coerce_type("text", "bool", False) == str(False)
     # text into bool
-    assert utils.coerce_type("bool", "text", "False") == False
+    assert utils.coerce_type("bool", "text", "False") is False
 
 
 def test_coerce_type_bool() -> None:

--- a/tests/common/schema/test_coercion.py
+++ b/tests/common/schema/test_coercion.py
@@ -11,6 +11,8 @@ def test_coerce_type_others() -> None:
     assert utils.coerce_type("double", "double", 8721.1) == 8721.1
     # anything into text
     assert utils.coerce_type("text", "bool", False) == str(False)
+    # text into bool
+    assert utils.coerce_type("bool", "text", "False") == False
 
 
 def test_coerce_type_bool() -> None:

--- a/tests/common/test_wei.py
+++ b/tests/common/test_wei.py
@@ -1,0 +1,27 @@
+from dlt.common.arithmetics import localcontext
+from dlt.common.wei import Wei, Decimal
+
+
+def test_init() -> None:
+    assert Wei(1) == 1
+    assert Wei(10**18, scale=18) == 1
+    assert type(Wei(1)) is Wei
+
+
+def test_wei_int() -> None:
+    assert Wei(1) == 1
+    assert Wei(2) > 1
+    x = Wei(10)
+    print(x)
+    d = {"a": Wei(20)}
+    print(d["a"].normalize())
+
+    class WeiContainer:
+        W = Wei(40)
+        def __init__(self) -> None:
+            self.w = Wei(20)
+
+    print(WeiContainer().w)
+    print(WeiContainer().W)
+    print(WeiContainer().w.normalize())
+    # assert Wei(10)**18 == 10**18

--- a/tests/dbt_runner/test_runner_redshift.py
+++ b/tests/dbt_runner/test_runner_redshift.py
@@ -25,7 +25,7 @@ DEST_SCHEMA_PREFIX = "test_" + uniq_id()
 @pytest.fixture(scope="module", autouse=True)
 def module_autouse() -> None:
     # disable GCP in environ
-    del environ["PROJECT_ID"]
+    del environ["GCP__PROJECT_ID"]
     # set the test case for the unit tests
     environ["DEFAULT_DATASET"] = "test_fixture_carbon_bot_session_cases"
     add_config_to_env(PostgresCredentials)

--- a/tests/dbt_runner/utils.py
+++ b/tests/dbt_runner/utils.py
@@ -3,7 +3,7 @@ from git import Repo
 import pytest
 from prometheus_client import CollectorRegistry
 
-from dlt.common.configuration import utils
+from dlt.common.configuration.providers import environ
 from dlt.common.typing import StrAny
 from dlt.dbt_runner.configuration import gen_configuration_variant
 from dlt.dbt_runner import runner
@@ -11,19 +11,19 @@ from dlt.dbt_runner import runner
 from tests.utils import clean_storage
 
 
-SECRET_STORAGE_PATH = utils.SECRET_STORAGE_PATH
+SECRET_STORAGE_PATH = environ.SECRET_STORAGE_PATH
 
 
 @pytest.fixture(autouse=True)
 def restore_secret_storage_path() -> None:
-    utils.SECRET_STORAGE_PATH = SECRET_STORAGE_PATH
+    environ.SECRET_STORAGE_PATH = SECRET_STORAGE_PATH
 
 
 def load_secret(name: str) -> str:
-    utils.SECRET_STORAGE_PATH = "./tests/dbt_runner/secrets/%s"
-    secret = utils._get_key_value(name, utils.TSecretValue)
+    environ.SECRET_STORAGE_PATH = "./tests/dbt_runner/secrets/%s"
+    secret = environ._get_key_value(name, environ.TSecretValue)
     if not secret:
-        raise FileNotFoundError(utils.SECRET_STORAGE_PATH % name)
+        raise FileNotFoundError(environ.SECRET_STORAGE_PATH % name)
     return secret
 
 

--- a/tests/load/bigquery/test_bigquery_table_builder.py
+++ b/tests/load/bigquery/test_bigquery_table_builder.py
@@ -19,11 +19,11 @@ def schema() -> Schema:
 
 def test_configuration() -> None:
     # check names normalized
-    with custom_environ({"PRIVATE_KEY": "---NO NEWLINE---\n"}):
+    with custom_environ({"GCP__PRIVATE_KEY": "---NO NEWLINE---\n"}):
         C = make_configuration(GcpClientCredentials, GcpClientCredentials)
         assert C.PRIVATE_KEY == "---NO NEWLINE---\n"
 
-    with custom_environ({"PRIVATE_KEY": "---WITH NEWLINE---\n"}):
+    with custom_environ({"GCP__PRIVATE_KEY": "---WITH NEWLINE---\n"}):
         C = make_configuration(GcpClientCredentials, GcpClientCredentials)
         assert C.PRIVATE_KEY == "---WITH NEWLINE---\n"
 

--- a/tests/load/redshift/test_redshift_table_builder.py
+++ b/tests/load/redshift/test_redshift_table_builder.py
@@ -26,7 +26,7 @@ def client(schema: Schema) -> RedshiftClient:
 
 def test_configuration() -> None:
     # check names normalized
-    with custom_environ({"DBNAME": "UPPER_CASE_DATABASE", "PASSWORD": " pass\n"}):
+    with custom_environ({"PG__DBNAME": "UPPER_CASE_DATABASE", "PG__PASSWORD": " pass\n"}):
         C = make_configuration(PostgresCredentials, PostgresCredentials)
         assert C.DBNAME == "upper_case_database"
         assert C.PASSWORD == "pass"


### PR DESCRIPTION
* allows setting `project_id` via config file/env when default GCP credentials are used. `project_id` if present overrides the one in default credentials
* experimental Streamlit helpers to: backup and restore pipeline state into `secrets.toml` and to write explore streamlit page to explore the schema
* experimental Pandas helper to read data from a destination into Panda frames using credentials already present in pipeline
* bumps to version `0.1.0rc11`